### PR TITLE
FIX : 도메인 객체 양방향 매핑 설정 및 예외 NotFoundException으로 바꾸기

### DIFF
--- a/src/main/java/com/knu/community/member/domain/Member.java
+++ b/src/main/java/com/knu/community/member/domain/Member.java
@@ -60,4 +60,6 @@ public class Member extends BaseTimeEntity {
     public void changeRole(MemberRole memberRole){
         this.role = memberRole;
     }
+
+    public void setProfile(Profile profile) { this.profile = profile; }
 }

--- a/src/main/java/com/knu/community/message/domain/Message.java
+++ b/src/main/java/com/knu/community/message/domain/Message.java
@@ -32,11 +32,29 @@ public class Message extends BaseTimeEntity {
     @JoinColumn
     private Member receiver;
 
+    public void setSender(Member sender) {
+        if(this.sender!=null){
+            this.sender.getSentMessageList().remove(this);
+        }
+        this.sender = sender;
+        sender.getSentMessageList().add(this);
+    }
+
+    public void setReceiver(Member receiver) {
+        if(this.receiver != null){
+            this.receiver.getReceivedMessageList().remove(this);
+        }
+        this.receiver = receiver;
+        receiver.getReceivedMessageList().add(this);
+    }
+
     public static Message createInstance(Member sender, Member receiver, String content){
-        return Message.builder()
+        Message message =  Message.builder()
                 .content(content)
                 .read(false)
-                .sender(sender)
-                .receiver(receiver).build();
+                .build();
+        message.setSender(sender);
+        message.setReceiver(receiver);
+        return message;
     }
 }

--- a/src/main/java/com/knu/community/message/repository/MessageRepository.java
+++ b/src/main/java/com/knu/community/message/repository/MessageRepository.java
@@ -3,9 +3,11 @@ package com.knu.community.message.repository;
 import com.knu.community.message.domain.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.swing.text.html.Option;
 import java.util.List;
+import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    List<Message> findAllByReceiver_Id(Long userId);
-    List<Message> findAllBySender_Id(Long userId);
+    Optional<List<Message>> findAllByReceiver_Id(Long userId);
+    Optional<List<Message>> findAllBySender_Id(Long userId);
 }

--- a/src/main/java/com/knu/community/message/service/SearchMessageService.java
+++ b/src/main/java/com/knu/community/message/service/SearchMessageService.java
@@ -1,6 +1,6 @@
 package com.knu.community.message.service;
 
-import com.knu.community.member.repository.MemberRepository;
+import com.knu.community.error.NotFoundException;
 import com.knu.community.message.domain.Message;
 import com.knu.community.message.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,16 +11,13 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class SearchMessageService {
-    private final MemberRepository memberRepository;
     private final MessageRepository msgRepository;
 
     public List<Message> searchReceived(Long userId) {
-        if(!memberRepository.existsById(userId)) throw new IllegalArgumentException("해당 유저가 없습니다.");
-        return msgRepository.findAllByReceiver_Id(userId);
+        return msgRepository.findAllByReceiver_Id(userId).orElseThrow(() -> new NotFoundException("메시지를 찾을 수 없습니다."));
     }
 
     public List<Message> searchSent(Long userId) {
-        if(!memberRepository.existsById(userId)) throw new IllegalArgumentException("해당 유저가 없습니다.");
-        return msgRepository.findAllBySender_Id(userId);
+        return msgRepository.findAllBySender_Id(userId).orElseThrow(() -> new NotFoundException("메시지를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/knu/community/message/service/SendMessageService.java
+++ b/src/main/java/com/knu/community/message/service/SendMessageService.java
@@ -1,5 +1,6 @@
 package com.knu.community.message.service;
 
+import com.knu.community.error.NotFoundException;
 import com.knu.community.member.domain.Member;
 import com.knu.community.member.repository.MemberRepository;
 import com.knu.community.message.domain.Message;
@@ -17,8 +18,8 @@ public class SendMessageService {
 
     @Transactional
     public void send(Long senderId, Long receiverId, MessageForm messageForm) {
-        Member sender = memberRepository.findById(senderId).orElseThrow(IllegalArgumentException::new);
-        Member receiver = memberRepository.findById(receiverId).orElseThrow(IllegalArgumentException::new);
+        Member sender = memberRepository.findById(senderId).orElseThrow(()-> new NotFoundException("해당 유저를 찾을 수 없습니다."));
+        Member receiver = memberRepository.findById(receiverId).orElseThrow(()-> new NotFoundException("해당 유저를 찾을 수 없습니다."));
 
         msgRepository.save(Message.createInstance(sender, receiver, messageForm.getContent()));
     }

--- a/src/main/java/com/knu/community/profile/domain/Profile.java
+++ b/src/main/java/com/knu/community/profile/domain/Profile.java
@@ -45,12 +45,19 @@ public class Profile extends BaseTimeEntity {
         return (changed == null || changed.equals("")) ? original : changed;
     }
 
+    public void setMember(Member member) {
+        this.member = member;
+        member.setProfile(this);
+    }
+
     public static Profile createProfile(Member member, ProfileForm profileForm){
-        return Profile.builder().language(profileForm.getLanguage())
+        Profile profile =  Profile.builder().language(profileForm.getLanguage())
                 .interest(profileForm.getInterest())
                 .githubLink(profileForm.getGithubLink())
                 .blogLink(profileForm.getBlogLink())
                 .imageLink(profileForm.getImageLink())
-                .member(member).build();
+                .build();
+        profile.setMember(member);
+        return profile;
     }
 }

--- a/src/main/java/com/knu/community/profile/service/ChangeProfileService.java
+++ b/src/main/java/com/knu/community/profile/service/ChangeProfileService.java
@@ -1,5 +1,6 @@
 package com.knu.community.profile.service;
 
+import com.knu.community.error.NotFoundException;
 import com.knu.community.profile.domain.Profile;
 import com.knu.community.profile.dto.ProfileForm;
 import com.knu.community.profile.repository.ProfileRepository;
@@ -14,7 +15,7 @@ public class ChangeProfileService {
 
     @Transactional
     public void changeProfile(Long memberId, ProfileForm profileForm) {
-        Profile profile = profileRepository.findByMember_Id(memberId).orElseThrow(()->new IllegalArgumentException("프로필이 없습니다."));
+        Profile profile = profileRepository.findByMember_Id(memberId).orElseThrow(() ->new NotFoundException("프로필이 없습니다."));
         profile.update(profileForm);
     }
 }

--- a/src/main/java/com/knu/community/profile/service/CreateProfileService.java
+++ b/src/main/java/com/knu/community/profile/service/CreateProfileService.java
@@ -1,5 +1,6 @@
 package com.knu.community.profile.service;
 
+import com.knu.community.error.NotFoundException;
 import com.knu.community.member.domain.Member;
 import com.knu.community.member.repository.MemberRepository;
 import com.knu.community.profile.domain.Profile;
@@ -17,7 +18,7 @@ public class CreateProfileService {
 
     @Transactional
     public void createProfile(Long memberId, ProfileForm profileForm) {
-        Member member = memberRepository.findById(memberId).orElseThrow(()->new IllegalArgumentException("사용자가 없습니다."));
+        Member member = memberRepository.findById(memberId).orElseThrow(()->new NotFoundException("사용자가 없습니다."));
         profileRepository.save(Profile.createProfile(member, profileForm));
     }
 }

--- a/src/main/java/com/knu/community/profile/service/SearchProfileService.java
+++ b/src/main/java/com/knu/community/profile/service/SearchProfileService.java
@@ -1,5 +1,6 @@
 package com.knu.community.profile.service;
 
+import com.knu.community.error.NotFoundException;
 import com.knu.community.profile.domain.Profile;
 import com.knu.community.profile.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,6 @@ public class SearchProfileService {
     private final ProfileRepository profileRepository;
 
     public Profile searchProfile(Long memberId) {
-        return profileRepository.findByMember_Id(memberId).orElseThrow(()->new IllegalArgumentException("프로필이 없습니다."));
+        return profileRepository.findByMember_Id(memberId).orElseThrow(()->new NotFoundException("프로필이 없습니다."));
     }
 }


### PR DESCRIPTION
## Pull Request

## 종류

- [ ] New Feature
- [X] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [X] Refactor

## 작업 내용

* Memeber와 Message, Member와 Profile 간 양방향 매핑 객체 단위에서 해줌
* illegalArgumentException -> NotFoundException으로 바꿈

## 변경로직


