### PR TITLE
FEAT: JWT Claim 수정 및 복호화 기능 구현

### DIFF
--- a/src/main/java/com/knu/community/board/controller/BoardController.java
+++ b/src/main/java/com/knu/community/board/controller/BoardController.java
@@ -33,17 +33,17 @@ public class BoardController {
         return boardService.findById(boardId);
     }
 
-    @GetMapping("/find")
+    @GetMapping("/findA")
     public List<Board> findBoardByTitle(@RequestParam("title") String title){
         return boardService.findByTitle(title);
     }
 
-    @GetMapping("/find")
+    @GetMapping("/findB")
     public List<Board> findBoardByCategory(@RequestParam("category") Category category){
         return boardService.findByCategory(category);
     }
 
-    @GetMapping("/find")
+    @GetMapping("/findC")
     public List<Board> findBoardByAuthor(@RequestParam("author") String author){
         return boardService.findByAuthor(author);
     }

--- a/src/main/java/com/knu/community/config/SecurityConfig.java
+++ b/src/main/java/com/knu/community/config/SecurityConfig.java
@@ -17,8 +17,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-            .mvcMatchers("/", "/user/signIn", "/user/signUp", "**/*", "/swagger-ui.html",
-                "/user/**").permitAll()
+            .mvcMatchers("/**", "/user/**", "/swagger-ui.html").permitAll()
             .mvcMatchers(HttpMethod.GET, "/profile/*").permitAll()
             .anyRequest().authenticated();
 

--- a/src/main/java/com/knu/community/email/service/AuthService.java
+++ b/src/main/java/com/knu/community/email/service/AuthService.java
@@ -8,8 +8,12 @@ import com.knu.community.member.domain.MemberRole;
 import com.knu.community.member.dto.SignInForm;
 import com.knu.community.member.dto.SignUpForm;
 import com.knu.community.member.repository.MemberRepository;
+import java.util.Base64;
 import java.util.UUID;
 import javassist.NotFoundException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -94,9 +98,19 @@ public class AuthService {
         memberRepository.save(member);
     }
 
-
-
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email);
+    }
+
+    public String getEmailFromJWT(HttpServletRequest req, HttpServletResponse res){
+        for (Cookie cookie : req.getCookies()) {
+            System.out.println(cookie.getName());
+            System.out.println(cookie.getValue());
+        }
+        String claim = req.getCookies()[0].getValue();
+        int start = claim.indexOf(".") + 1;
+        int end = claim.lastIndexOf(".");
+        String encodedPayload = claim.substring(start, end);
+        return new String(Base64.getDecoder().decode(encodedPayload)).split("\"")[3];
     }
 }

--- a/src/main/java/com/knu/community/email/service/MemberDetailsService.java
+++ b/src/main/java/com/knu/community/email/service/MemberDetailsService.java
@@ -16,12 +16,10 @@ public class MemberDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-
         Member member = memberRepository.findByEmail(email);
-        if(email == null){
+        if(member == null){
             throw new UsernameNotFoundException(email + " : 사용자 존재하지 않음");
         }
-
         return new SecurityMember(member);
     }
 }

--- a/src/main/java/com/knu/community/email/util/JwtRequestFilter.java
+++ b/src/main/java/com/knu/community/email/util/JwtRequestFilter.java
@@ -35,7 +35,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         final Cookie jwtToken = cookieUtil.getCookie(httpServletRequest,JwtUtil.ACCESS_TOKEN_NAME);
 
-        String username = null;
+        String email = null;
         String jwt = null;
         String refreshJwt = null;
         String refreshUname = null;
@@ -43,10 +43,10 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         try{
             if(jwtToken != null){
                 jwt = jwtToken.getValue();
-                username = jwtUtil.getUsername(jwt);
+                email = jwtUtil.getEmail(jwt);
             }
-            if(username!=null){
-                UserDetails userDetails = memberDetailsService.loadUserByUsername(username);
+            if(email!=null){
+                UserDetails userDetails = memberDetailsService.loadUserByUsername(email);
 
                 if(jwtUtil.validateToken(jwt,userDetails)){
                     UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails,null,userDetails.getAuthorities());
@@ -67,7 +67,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             if(refreshJwt != null){
                 refreshUname = redisUtil.getData(refreshJwt);
 
-                if(refreshUname.equals(jwtUtil.getUsername(refreshJwt))){
+                if(refreshUname.equals(jwtUtil.getEmail(refreshJwt))){
                     UserDetails userDetails = memberDetailsService.loadUserByUsername(refreshUname);
                     UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails,null,userDetails.getAuthorities());
                     usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(httpServletRequest));

--- a/src/main/java/com/knu/community/email/util/JwtUtil.java
+++ b/src/main/java/com/knu/community/email/util/JwtUtil.java
@@ -1,6 +1,5 @@
 package com.knu.community.email.util;
 
-
 import com.knu.community.member.domain.Member;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -40,8 +39,8 @@ public class JwtUtil {
             .getBody();
     }
 
-    public String getUsername(String token) {
-        return extractAllClaims(token).get("username", String.class);
+    public String getEmail(String token) {
+        return extractAllClaims(token).get("email", String.class);
     }
 
     public Boolean isTokenExpired(String token) {
@@ -49,18 +48,18 @@ public class JwtUtil {
         return expiration.before(new Date());
     }
 
-    public String generateToken(String username) {
-        return doGenerateToken(username, TOKEN_VALIDATION_SECOND);
+    public String generateToken(String email) {
+        return doGenerateToken(email, TOKEN_VALIDATION_SECOND);
     }
 
     public String generateRefreshToken(Member member) {
-        return doGenerateToken(member.getUsername(), REFRESH_TOKEN_VALIDATION_SECOND);
+        return doGenerateToken(member.getEmail(), REFRESH_TOKEN_VALIDATION_SECOND);
     }
 
-    public String doGenerateToken(String username, long expireTime) {
+    public String doGenerateToken(String email, long expireTime) {
 
         Claims claims = Jwts.claims();
-        claims.put("username", username);
+        claims.put("email", email);
 
         String jwt = Jwts.builder()
             .setClaims(claims)
@@ -73,8 +72,8 @@ public class JwtUtil {
     }
 
     public Boolean validateToken(String token, UserDetails userDetails) {
-        final String username = getUsername(token);
+        final String email = getEmail(token);
 
-        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+        return (email.equals(userDetails.getUsername()) && !isTokenExpired(token));
     }
 }

--- a/src/main/java/com/knu/community/member/controller/MemberController.java
+++ b/src/main/java/com/knu/community/member/controller/MemberController.java
@@ -37,26 +37,25 @@ public class MemberController {
     private final CookieUtil cookieUtil;
     private final RedisUtil redisUtil;
 
-//    @PostMapping("/signIn")
-//    public Response signIn(@Valid @RequestBody SignInForm signInForm, HttpServletRequest req, HttpServletResponse res) throws Exception {
-//        try {
-//            final Member member = authService.loginUser(signInForm);
-//            final String token = jwtUtil.generateToken(member.getUsername());
-//            final String refreshJwt = jwtUtil.generateRefreshToken(member);
-//            Cookie accessToken = cookieUtil.createCookie(JwtUtil.ACCESS_TOKEN_NAME, token);
-//            Cookie refreshToken = cookieUtil.createCookie(JwtUtil.REFRESH_TOKEN_NAME, refreshJwt);
-//            redisUtil.setDataExpire(refreshJwt, member.getUsername(), JwtUtil.REFRESH_TOKEN_VALIDATION_SECOND);
-//            res.addCookie(accessToken);
-//            res.addCookie(refreshToken);
-//            return new Response("success", "로그인에 성공했습니다.", token);
-//
-//        } catch (Exception e) {
-//            return new Response("false","로그인실패",null);
-//        }
-//    }
-
     @PostMapping("/signIn")
     public Response signIn(@Valid @RequestBody SignInForm signInForm, HttpServletRequest req, HttpServletResponse res) throws Exception {
+        try {
+            final Member member = authService.loginUser(signInForm);
+            final String token = jwtUtil.generateToken(member.getEmail());
+            final String refreshJwt = jwtUtil.generateRefreshToken(member);
+            Cookie accessToken = cookieUtil.createCookie(JwtUtil.ACCESS_TOKEN_NAME, token);
+            Cookie refreshToken = cookieUtil.createCookie(JwtUtil.REFRESH_TOKEN_NAME, refreshJwt);
+            redisUtil.setDataExpire(refreshJwt, member.getEmail(), JwtUtil.REFRESH_TOKEN_VALIDATION_SECOND);
+            res.addCookie(accessToken);
+            res.addCookie(refreshToken);
+            return new Response("success", "로그인에 성공했습니다.", token);
+        } catch (Exception e) {
+            return new Response("error", "로그인에 실패했습니다.", e.getMessage());
+        }
+    }
+
+    @PostMapping("/signInSession")
+    public Response signInSession(@Valid @RequestBody SignInForm signInForm, HttpServletRequest req, HttpServletResponse res) throws Exception {
         try {
             Member account = memberRepository.findByEmail(signInForm.getEmail());
 
@@ -116,5 +115,11 @@ public class MemberController {
             response = new Response("error", "인증메일을 확인하는데 실패했습니다.", null);
         }
         return response;
+    }
+
+    @GetMapping("/test")
+    public String getUserEmail(HttpServletRequest req, HttpServletResponse res){
+
+        return authService.getEmailFromJWT(req, res);
     }
 }


### PR DESCRIPTION
## Pull Request

## 종류

- [X] New Feature
- [X] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
- HTTP 요청 시 헤더에 JWT 추가해서 전송
- 요청 받은 JWT 에서 Claim 부분을 뗴어내어 복호화
- 유저의 이메일 획득 메소드 추가
- 기존에 username 으로 토큰 클레임 탐색 시 발생하던 오류 수정

## 변경로직
`JwtUtil`, `JwtRequestFilter` 에서 기존에 `member.username` 을 claim 에 추가해서 사용했었으나, unique key인 `member.email` 로 바꿔서 토큰 생성

