### PR TITLE
FEAT: 게시물 번호로 댓글&답글 조회, DTO 값 변경

### DIFF
--- a/src/main/java/com/knu/community/comment/controller/CommentController.java
+++ b/src/main/java/com/knu/community/comment/controller/CommentController.java
@@ -48,4 +48,10 @@ public class CommentController {
         return success(commentService.findMyComments(memId).stream().map(CommentDto::new)
         .collect(Collectors.toList()));
     }
+
+    @ApiOperation(value = "특정 게시판의 댓글 조회", notes = "게시판 아이디를 통해 특정 게시판의 댓글을 조회한다.")
+    @GetMapping("/findContentsByBoardId")
+    public ApiResult<List<CommentDto>> findContentsByBoardId(Long boardId){
+        return success(commentService.findContentsByBoardId(boardId));
+    }
 }

--- a/src/main/java/com/knu/community/comment/dto/CommentDto.java
+++ b/src/main/java/com/knu/community/comment/dto/CommentDto.java
@@ -2,21 +2,29 @@ package com.knu.community.comment.dto;
 
 
 import com.knu.community.comment.domain.Comment;
+import com.knu.community.reply.domain.Reply;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class CommentDto {
 
+    private Long commentId;
+
     private String author;
 
     private String content;
 
+    private List<Reply> replyList;
+
     private LocalDateTime time;
 
     public CommentDto(Comment comment){
+        this.commentId = getCommentId();
         this.author=comment.getAuthor();
         this.content=comment.getContent();
+        this.replyList = comment.getReplyList();
         this.time=comment.getLastModifiedDate();
     }
 }

--- a/src/main/java/com/knu/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/knu/community/comment/repository/CommentRepository.java
@@ -1,8 +1,10 @@
 package com.knu.community.comment.repository;
 
 import com.knu.community.comment.domain.Comment;
+import com.knu.community.comment.dto.CommentDto;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,5 +17,6 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     @Query("select m.commentList from Member m where m.id = :memId")
     Optional<List<Comment>> findMyComments(@Param(value="memId") Long memId);
 
-
+    @Query("select b.commentList from Board b where b.id = :boardId")
+    Optional<List<Comment>> findContentsByBoardId(@Param(value = "boardId") Long boardId);
 }

--- a/src/main/java/com/knu/community/comment/service/CommentService.java
+++ b/src/main/java/com/knu/community/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.knu.community.comment.service;
 import com.knu.community.board.domain.Board;
 import com.knu.community.board.repository.BoardRepository;
 import com.knu.community.comment.domain.Comment;
+import com.knu.community.comment.dto.CommentDto;
 import com.knu.community.comment.dto.CommentForm;
 import com.knu.community.comment.repository.CommentRepository;
 import com.knu.community.error.NotFoundException;
@@ -10,6 +11,7 @@ import com.knu.community.member.domain.Member;
 import com.knu.community.member.repository.MemberRepository;
 import com.knu.community.reply.repository.ReplyRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,4 +66,10 @@ public class CommentService {
         );
     }
 
+    public List<CommentDto> findContentsByBoardId(Long boardId) {
+        List<Comment> comments = commentRepository.findContentsByBoardId(boardId).orElseThrow(() ->
+            new NotFoundException("게시물이 존재하지 않습니다.")
+        );
+        return comments.stream().map(CommentDto::new).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/knu/community/member/dto/LoginSuccessDto.java
+++ b/src/main/java/com/knu/community/member/dto/LoginSuccessDto.java
@@ -1,0 +1,16 @@
+package com.knu.community.member.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginSuccessDto {
+
+    private Long userId;
+
+    private String nickname;
+
+    public LoginSuccessDto(Long userId, String nickname) {
+        this.userId = userId;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/knu/community/reply/domain/Reply.java
+++ b/src/main/java/com/knu/community/reply/domain/Reply.java
@@ -37,7 +37,7 @@ public class Reply extends BaseTimeEntity {
     private String author;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name="comment_id")
     @JsonIgnore
     private Comment comment;


### PR DESCRIPTION
## Pull Request

## 종류

- [X] New Feature
- [X] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
- 게시물 번호로 댓글과 답글을 한 번에 조회하는 API 기능 추가
- 반환 DTO 중 엔티티 기본 키가 필요한 곳에 추가

## 변경로직


